### PR TITLE
 catch exceptions on repo access issues (#9)

### DIFF
--- a/backupjca/__version__.py
+++ b/backupjca/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 __application_name__ = "backupjca"
 __author__ = "abel"
 __author_email__ = "j@abel.co"


### PR DESCRIPTION
* use same aws cli path throughout

* add optional user supplied github subdir
add type hints

* catch exceptions on repo access issues